### PR TITLE
Use CustomerIO Region 

### DIFF
--- a/lib/customerio/client.rb
+++ b/lib/customerio/client.rb
@@ -159,11 +159,11 @@ module Customerio
     end
 
     def add_entity_path
-      "https://track.customer.io/api/v2/entity"
+      "/api/v2/entity"
     end
 
     def track_push_notification_event_path
-        "/push/events"
+      "/push/events"
     end
 
     def merge_customers_path


### PR DESCRIPTION
Use CustomerIO region instead of hardcoded link

## How to Tests

<!> I couldn't test from Evalmee Directly <!>

So instead i tried in console directly

- cd lib
- Launch ./console
- export customerIO env variables (SITE_ID & API_KEY)
- Do the following commands

```ruby
CUSTOMERIO_CLIENT = Customerio::Client.new(ENV['CUSTOMER_IO_SITE_ID'], ENV['CUSTOMER_IO_TRACKING_API_KEY'], region: Customerio::Regions::EU)

CUSTOMERIO_CLIENT.identify_object(
       {
      object_type_id: "1",
      object_id: "666",
      },
      {
       name: "NewName",
       created_at: "school.created_at",
     },
   )
```


Check on customer IO to see if any changes occurs

![image](https://github.com/evalmee/customerio-ruby/assets/55443478/f284c824-f8af-41e7-8ca1-bad356ea048f)
